### PR TITLE
Refactors HexToBinary.js to reduce Cyclomatic Complexity

### DIFF
--- a/Conversions/HexToBinary.js
+++ b/Conversions/HexToBinary.js
@@ -1,23 +1,30 @@
+const hexTable = {
+  0: '0000',
+  1: '0001',
+  2: '0010',
+  3: '0011',
+  4: '0100',
+  5: '0101',
+  6: '0110',
+  7: '0111',
+  8: '1000',
+  9: '1001',
+  a: '1010',
+  A: '1010',
+  b: '1011',
+  B: '1011',
+  c: '1100',
+  C: '1100',
+  d: '1101',
+  D: '1101',
+  e: '1110',
+  E: '1110',
+  f: '1111',
+  F: '1111'
+}
+
 const binLookup = (c) => {
-  switch (c.toLowerCase()) {
-    case '0': return '0000'
-    case '1': return '0001'
-    case '2': return '0010'
-    case '3': return '0011'
-    case '4': return '0100'
-    case '5': return '0101'
-    case '6': return '0110'
-    case '7': return '0111'
-    case '8': return '1000'
-    case '9': return '1001'
-    case 'a': return '1010'
-    case 'b': return '1011'
-    case 'c': return '1100'
-    case 'd': return '1101'
-    case 'e': return '1110'
-    case 'f': return '1111'
-    default: return ''
-  }
+  return hexTable[c] || ''
 }
 const hexToBinary = (hexString) => {
   /*

--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -70,6 +70,7 @@
     * [MinHeap](https://github.com/TheAlgorithms/Javascript/blob/master/Data-Structures/Heap/MinHeap.js)
     * [MinPriorityQueue](https://github.com/TheAlgorithms/Javascript/blob/master/Data-Structures/Heap/MinPriorityQueue.js)
   * Linked-List
+    * [AddTwoNumbers](https://github.com/TheAlgorithms/Javascript/blob/master/Data-Structures/Linked-List/AddTwoNumbers.js)
     * [CycleDetection](https://github.com/TheAlgorithms/Javascript/blob/master/Data-Structures/Linked-List/CycleDetection.js)
     * [DoublyLinkedList](https://github.com/TheAlgorithms/Javascript/blob/master/Data-Structures/Linked-List/DoublyLinkedList.js)
     * [RotateListRight](https://github.com/TheAlgorithms/Javascript/blob/master/Data-Structures/Linked-List/RotateListRight.js)


### PR DESCRIPTION
Fixes #38 
Refactored binLookup() Function in a way that gets rid of switch case oriented lookup in favor of map based lookup function. Reducing Cyclomatic complexity from 17 to 2